### PR TITLE
Add only in prod example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,18 +33,33 @@ const { useTreblle } = require("treblle");
 ```
 
 ## Getting started
-Next, create a FREE account on <https://treblle.com> to get an API key and Project ID. After you have those simply initialize Treblle in your **app.js** file like so: 
+Next, create a FREE account on <https://treblle.com> to get an API key and Project ID. After you have those simply initialize Treblle in your **app.js** file like so:
 
 ```js
 const app = express();
 app.use(express.json());
 
 useTreblle(app, {
-  apiKey: '_YOUR_API_KEY_',
-  projectId: '_YOUR_PROJECT_ID_',
+  apiKey: "_YOUR_API_KEY_",
+  projectId: "_YOUR_PROJECT_ID_",
 });
 ```
 That's it. Your API requests and responses are now being sent to your Treblle project. Just by adding that line of code you get features like: auto-documentation, real-time request/response monitoring, error tracking and so much more.
+
+### Running Treblle only in production
+If you want to run Treblle only in production, you can rely on the environment variables, or use a similar approach via config.
+
+```js
+const app = express();
+app.use(express.json());
+
+if (process.env.NODE_ENV === "production") {
+  useTreblle(app, {
+    apiKey: "_YOUR_API_KEY_",
+    projectId: "_YOUR_PROJECT_ID_",
+  });
+}
+```
 
 ## Support
 If you have problems of any kind feel free to reach out via <https://treblle.com> or email vedran@treblle.com and we'll do our best to help you out.


### PR DESCRIPTION
Expands README with an example of how to run treblle only in prod