### PR TITLE
fix(strapi): ignoreAdminRoutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,6 @@ Then enable the Treblle middleware in `config/middleware.js` like this:
 
 ```js
 module.exports = {
-  load: {
-    before: ["boom", "treblle"],
-  },
   settings: {
     treblle: {
       enabled: true,

--- a/src/treblle.js
+++ b/src/treblle.js
@@ -155,7 +155,7 @@ function koaTreblle({
  * @param {string} projectId Treblle Project ID
  * @param {string[]?} additionalFieldsToMask specify additional fields to hide
  * @param {boolean?} showErrors controls error logging when sending data to Treblle
- * @param {boolean?} ignoreAdminRoutes controls logging /admin routes
+ * @param {string[]} ignoreAdminRoutes controls logging /admin routes
  * @returns {function} koa middleware function
  */
 function strapiTreblle({
@@ -163,13 +163,18 @@ function strapiTreblle({
   projectId,
   additionalFieldsToMask = [],
   showErrors = true,
-  ignoreAdminRoutes = true,
+  ignoreAdminRoutes = [
+    "admin",
+    "content-type-builder",
+    "content-manager",
+  ]
 }) {
   const fieldsToMaskMap = generateFieldsToMaskMap(additionalFieldsToMask);
 
   return async function (ctx, next) {
     // option to ignore admin routes since everything is served via koa
-    if (ignoreAdminRoutes && ctx.request.url.startsWith("/admin")) {
+    const [_, path] = ctx.request.url.split("/");
+    if (ignoreAdminRoutes.includes(path)) {
       return next();
     }
 


### PR DESCRIPTION
Adds missing paths from Strapi admin plugins and provides the ability to the user to customize it if needed