### PR TITLE
Add typescript module declearation to fix typescript error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,18 @@
+declare module "treblle" {
+  export function useTreblle(app: any, options: any): void;
+
+  export function koaTreblle(
+    apiKey: string,
+    projectId: string,
+    additionalFieldsToMask?: any[],
+    showErrors?: boolean
+  ): Function;
+
+  export function strapiTreblle(
+    apiKey: string,
+    projectId: string,
+    additionalFieldsToMask?: any[],
+    showErrors?: boolean,
+    ignoreAdminRoutes?: string[]
+  ): Function;
+}


### PR DESCRIPTION
when this package import like `import { useTreblle } from 'treblle'` has typescript error.
to fix it i created index.d.ts file and it resolve this