### PR TITLE
Use ctx wait until

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@
 
 [Website](http://treblle.com/) • [Documentation](https://docs.treblle.com/) • [Pricing](https://treblle.com/pricing)
 
-
 Treblle is an API intelligence platfom that helps developers, teams and organizations understand their APIs from a single integration point.
 
-***
+---
 
 ## Treblle JavaScript SDK
 
@@ -54,9 +53,9 @@ const { useTreblle } = require("treblle");
 
 - The old `apiKey` value is now called `sdkToken` to match our new naming conventions
 - The old `projectId` value is now called `apiKey` to match our new naming convetions
-- `showErrors` is now renamed to `debug` for more clarity 
+- `showErrors` is now renamed to `debug` for more clarity
 
-For more details on other changes and improvments please take a look at the [Changelog](#changelog) section. 
+For more details on other changes and improvments please take a look at the [Changelog](#changelog) section.
 
 ## Getting started
 
@@ -622,7 +621,8 @@ blocklistPaths: ["admin", /^\/api\/v1\/internal/];
 ## Changelog
 
 ### v2.0
-- Dramatically improved networking perfomrance 
+
+- Dramatically improved networking perfomrance
 - Dramatically improved memory usage and consumption
 - Dramatically improved masking perfomrance
 - Added support for Hono
@@ -630,7 +630,6 @@ blocklistPaths: ["admin", /^\/api\/v1\/internal/];
 - Added built-in endpoint detection
 - Improved Debugging
 - Improved Readme with more examples
-
 
 ## Troubleshooting
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "treblle",
-  "version": "1.5.3-beta.10",
+  "version": "2.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treblle",
-      "version": "1.5.3-beta.10",
+      "version": "2.0.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "finalhandler": "~1.1.2",

--- a/src/sender.js
+++ b/src/sender.js
@@ -540,7 +540,7 @@ function sendKoaPayloadToTreblle(
   sendPayloadToTreblleApi({ apiKey: sdkToken, trebllePayload, debug });
 }
 
-function sendHonoPayloadToTreblle(
+async function sendHonoPayloadToTreblle(
   honoContext,
   { sdkToken, apiKey, requestStartTime, fieldsToMaskMap, debug, error }
 ) {
@@ -551,11 +551,20 @@ function sendHonoPayloadToTreblle(
     error,
     fieldsToMaskMap,
   });
-
-  sendPayloadToTreblleApi({ apiKey: sdkToken, trebllePayload, debug });
+  return sendPayloadToTreblleApiAsync({
+    apiKey: sdkToken,
+    trebllePayload,
+    debug,
+  });
 }
 
 function sendPayloadToTreblleApi({ apiKey, trebllePayload, debug }) {
+  sendPayloadToTreblleApiAsync({ apiKey, trebllePayload, debug }).then(
+    () => {},
+    () => {}
+  );
+}
+async function sendPayloadToTreblleApiAsync({ apiKey, trebllePayload, debug }) {
   let f;
   if (typeof fetch === "function") {
     f = fetch;
@@ -574,7 +583,7 @@ function sendPayloadToTreblleApi({ apiKey, trebllePayload, debug }) {
 
   const endpoint = getRandomEndpoint();
 
-  f(endpoint, {
+  await f(endpoint, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/src/treblle.js
+++ b/src/treblle.js
@@ -361,6 +361,29 @@ function honoTreblle({
   };
 }
 
+async function honoTask({
+  c,
+  sdkToken,
+  apiKey,
+  requestStartTime,
+  fieldsToMaskMap,
+  debug,
+  error,
+}) {
+  try {
+    await captureHonoResponseBody(c);
+  } finally {
+    await sendHonoPayloadToTreblle(c, {
+      sdkToken,
+      apiKey,
+      requestStartTime,
+      fieldsToMaskMap,
+      debug,
+      error,
+    })
+  }
+}
+
 async function honoMiddlewareFn({
   c,
   next,
@@ -370,29 +393,33 @@ async function honoMiddlewareFn({
   debug,
 }) {
   const requestStartTime = process.hrtime();
+  const wrapper = 'executionCtx' in c ? c.executionCtx.waitUntil.bind(c.executionCtx) : (p) => p.catch(() => {})
 
   try {
     await next();
+    wrapper(
+      honoTask({
+        c,
+        sdkToken,
+        apiKey,
+        requestStartTime,
+        fieldsToMaskMap,
+        debug,
+      })
+    );
 
-    // Capture response body for Hono
-    await captureHonoResponseBody(c);
-
-    sendHonoPayloadToTreblle(c, {
-      sdkToken,
-      apiKey,
-      requestStartTime,
-      fieldsToMaskMap,
-      debug,
-    });
   } catch (error) {
-    sendHonoPayloadToTreblle(c, {
-      sdkToken,
-      apiKey,
-      requestStartTime,
-      fieldsToMaskMap,
-      debug,
-      error,
-    });
+    wrapper(
+      honoTask({
+        c,
+        sdkToken,
+        apiKey,
+        requestStartTime,
+        fieldsToMaskMap,
+        debug,
+        error,
+      })
+    );
     throw error;
   }
 }


### PR DESCRIPTION
Hono can optionally run in a cloudflare worker envirionment.

When running in a cf worker, the executor is killed after the response is sent, this means that there is not enough time for the payload to be sent to treblle.

However, in this case Hono exposes the cloudflare execution context (docs: https://hono.dev/docs/api/context#executionctx) which allows us to call c.executionCtx.waitUntil(<promise>) so we can wait for the payload to be sent to treblle before the executor is killed.

This is a very rough and ready implementation. I just wanted to get something I could test.