### PR TITLE
calculate hono response body from ArrayBuffer size when decoding

### DIFF
--- a/src/sender.js
+++ b/src/sender.js
@@ -297,7 +297,7 @@ const generateHonoTrebllePayload = function (
     fieldsToMaskMap
   );
 
-  const responseHeaders = honoContext.res.headers;
+  let responseBodySize = honoContext.__treblle_body_response_size || null;
 
   let errors = [];
 
@@ -327,6 +327,7 @@ const generateHonoTrebllePayload = function (
     }
   } catch {
     // if we can't parse the body we'll leave it empty and set an error
+    responseBodySize = null;
     errors.push({
       source: "onShutdown",
       type: "INVALID_JSON",
@@ -387,7 +388,7 @@ const generateHonoTrebllePayload = function (
           fieldsToMaskMap
         ),
         code: honoContext.res.status,
-        size: null, // Hono doesn't expose content length easily
+        size: responseBodySize,
         load_time: getRequestDuration(requestStartTime),
         body: maskedResponseBody !== undefined ? maskedResponseBody : null,
       },

--- a/src/treblle.js
+++ b/src/treblle.js
@@ -493,27 +493,30 @@ async function captureHonoResponseBody(c) {
       // Clone the response to read the body without consuming it
       const clonedResponse = c.res.clone();
 
-      // Try to read as text first
-      let responseBody;
+      let responseBody, responseBodySize
+      if (clonedResponse.headers.has('content-length')) {
+        responseBodySize = parseInt(clonedResponse.headers.get('content-length'));
+      }
       try {
-        responseBody = await clonedResponse.text();
-      } catch {
-        // If text fails, try reading as arrayBuffer and convert
-        try {
-          const buffer = await clonedResponse.arrayBuffer();
-          responseBody = new TextDecoder().decode(buffer);
-        } catch {
-          // If all fails, leave it null
-          responseBody = null;
+        const buffer = await clonedResponse.arrayBuffer();
+        responseBody = new TextDecoder().decode(buffer);
+        if (!responseBodySize) {
+          responseBodySize = buffer.byteLength;
         }
+      } catch {
+        // If all fails, leave it null
+        responseBodySize = null;
+        responseBody = null;
       }
 
       // Store captured body for later access
       c.__treblle_body_response = responseBody;
+      c.__treblle_body_response_size = responseBodySize;
     }
   } catch (error) {
     // If capture fails, continue without body data
     c.__treblle_body_response = null;
+    c.__treblle_body_response_size = null;
   }
 }
 


### PR DESCRIPTION
By decoding the clonedResponse's body into an ArrayBuffer, we can use it's byteLength for the response size.